### PR TITLE
fix buffer limit issue and improve performance

### DIFF
--- a/appender-core/src/main/java/com/van/logging/IFlushAndPublish.java
+++ b/appender-core/src/main/java/com/van/logging/IFlushAndPublish.java
@@ -1,6 +1,5 @@
 package com.van.logging;
 
-import java.util.concurrent.Future;
 
 /**
  * An interface for an implementation that will flush and publish
@@ -10,9 +9,6 @@ public interface IFlushAndPublish {
     /**
      * Flush and publish cached content and return a Future &lt;Boolean&gt;
      * for the result.
-     *
-     * @return Future &lt;Boolean&gt; for the result. This CAN BE
-     * <code>null</code> if there was nothing published.
      */
-    Future<Boolean> flushAndPublish();
+    void flushAndPublish();
 }

--- a/appender-core/src/test/java/com/van/logging/AbstractBufferMonitorTest.java
+++ b/appender-core/src/test/java/com/van/logging/AbstractBufferMonitorTest.java
@@ -1,7 +1,6 @@
 package com.van.logging;
 
 import org.junit.Before;
-import java.util.concurrent.Future;
 
 /**
  * Abstract base class for monitor tests. Shared facilities for testing
@@ -12,10 +11,9 @@ public abstract class AbstractBufferMonitorTest {
 
     protected IFlushAndPublish publisher = new IFlushAndPublish() {
         @Override
-        public Future<Boolean> flushAndPublish() {
+        public void flushAndPublish() {
             System.out.println("flushAndPublish() called.");
             publishCount++;
-            return null;
         }
     };
 


### PR DESCRIPTION
There was an issue with buffer size limit when pushing logs to aws more than buffer limit at high rate.

For example if buffer limit is set to 100 and 200 log events were sent, then the first file sent to aws will have 200 records and second file will be empty, as the buffer wasn't being closed immediately when reaching the limit , so new events were still being added to the previous buffer.

New implementation using blocking queue and the buffer is closed once limit reached and publish event is pushed to the consumer thread.

Also there there is performance improvement in this change to use memory buffer instead of file buffer before reaching the buffer limit.